### PR TITLE
修复当参数为空时造成的exception

### DIFF
--- a/back-end/src/main/java/com/github/ontio/task/TxnHandlerThread.java
+++ b/back-end/src/main/java/com/github/ontio/task/TxnHandlerThread.java
@@ -135,6 +135,11 @@ public class TxnHandlerThread {
      * @return
      */
     private byte[] format(List byteList) {
+
+        if ((byteList instanceof List) == false) {
+          return new byte[0];
+        }
+
         byte[] bys = new byte[byteList.toArray().length];
         for (int i = 0; i < bys.length; i++) {
             bys[i] = (byte) ((int) byteList.get(i) & 0xff);


### PR DESCRIPTION
执行某些智能合约完成后同步的时候可能会造成空指针的exception