### PR TITLE
Remove word consensus

### DIFF
--- a/front-end/src/common/lang/en.js
+++ b/front-end/src/common/lang/en.js
@@ -71,7 +71,7 @@ module.exports = {
     CurrentHeight: 'Block Height',
     BlockInterval: 'Average Block Time',
     TxnCount: 'Total Transactions',
-    NodeCount: 'Consensus Nodes',
+    NodeCount: 'Nodes',
     addressCount: 'Total addresses',
     second: 's',
     address: "addresses",


### PR DESCRIPTION
The node count on https://explorer.ont.io is not the total consensus nodes, but the consensus plus candidate nodes.